### PR TITLE
Add ChanOps to #miraheze-feed-test

### DIFF
--- a/modules/profile/files/channelmgnt.json
+++ b/modules/profile/files/channelmgnt.json
@@ -177,7 +177,7 @@
       "chanops":[
          "dmehus",
          "Reception123",
-         "PuppyKun",
+         "NDKilla",
          "Voidwalker",
          "Zppix",
          "RhinosF1",

--- a/modules/profile/files/channelmgnt.json
+++ b/modules/profile/files/channelmgnt.json
@@ -172,7 +172,7 @@
          "Reception123",
          "Universal_Omega"
       ]
-   }
+   },
     "#miraheze-feed-test":{
       "chanops":[
          "dmehus",

--- a/modules/profile/files/channelmgnt.json
+++ b/modules/profile/files/channelmgnt.json
@@ -173,4 +173,15 @@
          "Universal_Omega"
       ]
    }
+    "#miraheze-feed-test":{
+      "chanops":[
+         "dmehus",
+         "Reception123",
+         "PuppyKun",
+         "Voidwalker",
+         "Zppix",
+         "RhinosF1",
+         "MacFan4000"
+      ]
+   }
 }


### PR DESCRIPTION
Setting as Consuls + MacFan4000 for mostly technical reasons. Any kicks/bans MacFan4000 performs in this channel are subject to Consul review and/or override. Also, some of these users haven't been granted flags in the channel by ChanServ, but assuming ChanOps is not dependent on that