### PR TITLE
git::clone: set depth to 1 by default

### DIFF
--- a/modules/git/manifests/clone.pp
+++ b/modules/git/manifests/clone.pp
@@ -58,7 +58,7 @@ define git::clone(
     $group='root',
     $shared=false,
     $timeout='300',
-    $depth='full',
+    $depth=1,
     $bare=false,
     $recurse_submodules=false,
     $umask=undef,


### PR DESCRIPTION
Saves space.

Repos will need recloning for this.