### PR TITLE
fix check_systemd_state

### DIFF
--- a/modules/icinga2/templates/zones.d/global-templates/commands.conf
+++ b/modules/icinga2/templates/zones.d/global-templates/commands.conf
@@ -87,5 +87,5 @@ object CheckCommand "check_stream_run" {
 object CheckCommand "check_systemd_state" {
       import "plugin-check-command"
 
-      command = [ PluginDir + "/check_systemd_state" + " $service$"]
+      command = [ PluginDir + "/check_systemd_state", "$service$"]
 }


### PR DESCRIPTION
add arguments by extending the array, otherwise I believe it is looking for a literal file like `/usr/lib/nagios/plugins/check_systemd_state run-puppet` (including the space!)