### PR TITLE
remove second entry for test2001

### DIFF
--- a/hieradata/hosts/mirahezebots-fhc-test2001.yaml
+++ b/hieradata/hosts/mirahezebots-fhc-test2001.yaml
@@ -1,3 +1,0 @@
-users::groups:
-  - grouponeshell
-icinga::nodename: 'test2001.mirahezebots.org'

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -11,6 +11,3 @@ node 'db1.mirahezebots.org' {
 node 'test2001.mirahezebots.org' {
   include role::testnet
  }
- node 'mirahezebots-fhc-test2001' {
-  include role::testnet
- }


### PR DESCRIPTION
I was able to make the hostname stay set to test2001.mirahezebots.org by editing the cloud-init config