### PR TITLE
mhlibera: re-allow coco per discord mods

### DIFF
--- a/modules/profile/templates/mhliberaconfig.json
+++ b/modules/profile/templates/mhliberaconfig.json
@@ -21,7 +21,6 @@
             "icinga-miraheze",
             "mirahezebots_",
             "ZppixBot",
-            "Cocopuff2018",
             "blackwidowmovie0"
          ]
       },


### PR DESCRIPTION
Implements step 2 of a three-step process that would see Cocopuff2018 eventually unbanned from Discord, subject, of course, to the same restrictions currently in place on IRC, which for ease of recall are published at https://www.irccloud.com/pastebin/poFUSG3P/.

@Reception123, can you merge the above, please, in your dual capacity as MirahezeBots operator and Discord/IRC platform moderator? Thank you. :)