### PR TITLE
mhlibera: re-enable Coco

### DIFF
--- a/modules/profile/templates/mhliberaconfig.json
+++ b/modules/profile/templates/mhliberaconfig.json
@@ -21,7 +21,6 @@
             "icinga-miraheze",
             "mirahezebots_",
             "ZppixBot",
-            "Cocopuff2018",
             "blackwidowmovie0"
          ]
       },


### PR DESCRIPTION
For when discord ban is lifted, 2 users with IBANs must be informed of this and we must be alerted as soon as they are any complaints regarding use of the relay.

Coco should be reminded that any misuse will be taken extremely seriously if it occurs and I will be banging on the doors of moderators if I have to deal with it.